### PR TITLE
Add support for aarch64

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/bin/sh -ex
 VERSION=0.16.4
-wget https://github.com/restic/restic/releases/download/v${VERSION}/restic_${VERSION}_linux_amd64.bz2
-bunzip2 restic_${VERSION}_linux_amd64.bz2
-mv restic_${VERSION}_linux_amd64 restic
+ARCH=${DEB_TARGET_ARCH}
+wget https://github.com/restic/restic/releases/download/v${VERSION}/restic_${VERSION}_linux_${ARCH}.bz2
+bunzip2 restic_${VERSION}_linux_${ARCH}.bz2
+mv restic_${VERSION}_linux_${ARCH} restic

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 4.4.0
 Homepage: https://github.com/restic/restic/releases
 
 Package: restic
-Architecture: amd64
+Architecture: amd64 arm64
 Description: restic is a backup program that is fast, efficient and secure
  restic is a backup program that is fast, efficient and secure.


### PR DESCRIPTION
Starting off with an easy change on the path toward arm64 support.  Upstream restic provides arm64 support, so we can just parameterize the build script.